### PR TITLE
Fix app crash when selecting some lat&lng using place picker

### DIFF
--- a/ios/Classes/TiGooglemapsPlacePickerDialogProxy.m
+++ b/ios/Classes/TiGooglemapsPlacePickerDialogProxy.m
@@ -107,12 +107,14 @@
 
 + (NSDictionary *)dictionaryFromPlace:(GMSPlace *)place
 {
+    NSString * formattedAddress = [place formattedAddress];
+    
   return @{
     @"name" : [place name],
     @"placeID" : [place placeID],
     @"latitude" : NUMDOUBLE([place coordinate].latitude),
     @"longitude" : NUMDOUBLE([place coordinate].longitude),
-    @"formattedAddress" : [place formattedAddress],
+    @"formattedAddress" : (formattedAddress != nil ? formattedAddress : @""),
     @"addressComponents" : [TiGooglemapsPlacePickerDialogProxy arrayFromAddressComponents:[place addressComponents]]
   };
 }

--- a/ios/Classes/TiGooglemapsPlacePickerDialogProxy.m
+++ b/ios/Classes/TiGooglemapsPlacePickerDialogProxy.m
@@ -107,14 +107,12 @@
 
 + (NSDictionary *)dictionaryFromPlace:(GMSPlace *)place
 {
-    NSString * formattedAddress = [place formattedAddress];
-    
   return @{
     @"name" : [place name],
     @"placeID" : [place placeID],
     @"latitude" : NUMDOUBLE([place coordinate].latitude),
     @"longitude" : NUMDOUBLE([place coordinate].longitude),
-    @"formattedAddress" : (formattedAddress != nil ? formattedAddress : @""),
+    @"formattedAddress" : NULL_IF_NIL([place formattedAddress]),
     @"addressComponents" : [TiGooglemapsPlacePickerDialogProxy arrayFromAddressComponents:[place addressComponents]]
   };
 }


### PR DESCRIPTION
When opening place picker and picking any location in suggested locations list the app crash if the lat&lng points to some place with no formatted address. Some places in mid-east have no formatted address so the place picker cause the whole application to crash if picking any of these locations.